### PR TITLE
Add support for RPC API version 10

### DIFF
--- a/rtorrent_throttle.py
+++ b/rtorrent_throttle.py
@@ -12,8 +12,9 @@ RTORRENT_URL	= ""
 RPC_PATH	= "RPC2"
 RTORRENT_RPC	= f"https://{RTORRENT_USER}:{RTORRENT_PASS}@{RTORRENT_URL}/{RPC_PATH}"
 
+SUPPORTED_API_VERSIONS = [9, 10]
 IGNORE_SSL_CERT	= False
-DEBUG	= False
+DEBUG	= True
 
 class throttle():
 	def __init__(self):
@@ -32,8 +33,11 @@ class throttle():
 	def check_connection(self):
 		try:
 			self.log_msg("[*] Checking RPC server connection")
-			self.rpc_server.throttle.global_up.max_rate("")
-			self.log_msg("[+] RPC server connection is OK")
+			self.rpc_api_version = int(self.rpc_server.system.api_version(""))
+			if self.rpc_api_version not in SUPPORTED_API_VERSIONS:
+				self.log_msg("[+] RPC API version is not supported")
+				return False
+			self.log_msg(f"[+] RPC server connection is OK. API Version: {self.rpc_api_version}")
 			return True
 		except xmlrpc.client.ProtocolError:
 			self.log_msg("[-] Failed connection to RPC server", is_exception=True)
@@ -55,25 +59,30 @@ class throttle():
 		return self.rpc_server.throttle.global_up.max_rate.set_kb("", rate) == 0
 
 	def format_speed(self, rate):
-		if rate == 335488000:
+		if rate == 335488000 or rate == 327625:
 			return "Unlimited"
-		return f"{int(rate/1024)}KB/s"
+		return f"{rate}KB/s"
 
 	def throttle_download(self, rate):
 		before = self.get_max_download_rate()
+		before_kbs = int(before/1024)
+		maxdownload = rate
 
 		# If -1 set to unlimited
 		if rate == -1:
-			maxdownload = 335488000
-		else:
-			maxdownload = rate * 1024
-
-		if maxdownload == before:
-			self.log_msg(f"[*] New max upload rate is already set: {self.format_speed(maxdownload)}")
+			maxdownload = 327625
+		
+		if maxdownload == before_kbs:
+			self.log_msg(f"[*] New max download rate is already set: {self.format_speed(maxdownload)}")
 			return True
 
-		self.log_msg(f"[+] Previous max download rate: {self.format_speed(before)}")
+		self.log_msg(f"[+] Previous max download rate: {self.format_speed(before_kbs)}")
 		self.log_msg(f"[*] Setting max download rate: {self.format_speed(maxdownload)}")
+
+		# Fix bug in API version 9 where set_kb() sets bytes instead of kilobytes
+		if self.rpc_api_version == 9:
+			maxdownload *= 1024
+		
 		if not self.set_max_download_rate(maxdownload):
 			self.log_msg("[-] Failed setting max download rate")
 			return False
@@ -87,19 +96,24 @@ class throttle():
 
 	def throttle_upload(self, rate):
 		before = self.get_max_upload_rate()
+		before_kbs = int(before/1024)
+		maxupload = rate
 
 		# If -1 set to unlimited
 		if rate == -1:
-			maxupload = 335488000
-		else:
-			maxupload = rate * 1024
-
-		if maxupload == before:
+			maxupload = 327625
+		
+		if maxupload == before_kbs:
 			self.log_msg(f"[*] New max upload rate is already set: {self.format_speed(maxupload)}")
 			return True
 
-		self.log_msg(f"[+] Previous max upload rate: {self.format_speed(before)}")
+		self.log_msg(f"[+] Previous max upload rate: {self.format_speed(before_kbs)}")
 		self.log_msg(f"[*] Setting max upload rate: {self.format_speed(maxupload)}")
+
+		# Fix bug in API version 9 where set_kb() sets bytes instead of kilobytes
+		if self.rpc_api_version == 9:
+			maxupload *= 1024
+		
 		if not self.set_max_upload_rate(maxupload):
 			self.log_msg("[-] Failed setting max upload rate")
 			return False

--- a/rtorrent_throttle.py
+++ b/rtorrent_throttle.py
@@ -14,7 +14,7 @@ RTORRENT_RPC	= f"https://{RTORRENT_USER}:{RTORRENT_PASS}@{RTORRENT_URL}/{RPC_PAT
 
 SUPPORTED_API_VERSIONS = [9, 10]
 IGNORE_SSL_CERT	= False
-DEBUG	= True
+DEBUG	= False
 
 class throttle():
 	def __init__(self):


### PR DESCRIPTION
Fix #1 .
In old API version 9, the `set_kb()` method call had a bug which set it as bytes instead of kilobytes.
API version 10 fixed it.
Add support for version 10, while being backward compatibile with buggy version 9.